### PR TITLE
更改组件Layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "refreshable_view_miniprogram",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "miniprogram_dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,6 @@ Component({
           .in(this)
           .select('#container')
           .boundingClientRect((res) => {
-            console.log(res)
             this.containerRect = {
               left: res.left, top: res.top, width: res.width, height: res.height
             }
@@ -122,7 +121,6 @@ Component({
               .select('#container-view')
               .boundingClientRect(res => {
                 const info = wx.getSystemInfoSync()
-                console.log(info.platform)
                 this.contentRect = {
                   left: res.left, top: res.top - 8, width: res.width, height: res.height + (info.platform === 'ios' ? 8 : 16)
                 }
@@ -535,16 +533,8 @@ Component({
       }
     },
     onScroll(e) {
-      console.log('==========')
-      console.log(this.leadingRefresherState)
-      console.log(this.trailingRefresherState)
       if (this.leadingRefresherState.value === 'pulling' || this.trailingRefresherState.value === 'pulling') return
       const {scrollTop} = e.detail
-      console.log('--------------------------')
-      console.log(e.detail)
-      console.log(this.contentRect)
-      console.log(this.leadingScrollViewOffset)
-      console.log(this.trailingScrollViewOffset)
       this.leadingScrollViewOffset = scrollTop
       this.trailingScrollViewOffset = this.contentRect.height -
         this.containerRect.height - this.leadingScrollViewOffset

--- a/src/index.js
+++ b/src/index.js
@@ -340,8 +340,7 @@ Component({
           action: (offset, percentage) => {
             this.setData({
               leadingPullingOffset: offset,
-              leadingPullingPercentage: percentage,
-              scrollTop: this.leadingScrollViewOffset
+              leadingPullingPercentage: percentage
             })
           }
         })
@@ -358,8 +357,7 @@ Component({
           action: (offset, percentage) => {
             this.setData({
               trailingPullingOffset: offset,
-              trailingPullingPercentage: percentage,
-              scrollTop: this.leadingScrollViewOffset
+              trailingPullingPercentage: percentage
             })
           }
         })

--- a/src/index.js
+++ b/src/index.js
@@ -96,14 +96,14 @@ Component({
     updateScrollViewOffsets() {
       this.updateBoundingRect()
         .then(res => {
-          console.log(res)
+          // console.log(res)
           if (this.leadingScrollViewOffset === undefined) {
             this.leadingScrollViewOffset = 0
           }
           this.trailingScrollViewOffset = res.contentRect.height -
             res.containerRect.height - this.leadingScrollViewOffset
-          console.log(this.leadingScrollViewOffset)
-          console.log(this.trailingScrollViewOffset)
+          // console.log(this.leadingScrollViewOffset)
+          // console.log(this.trailingScrollViewOffset)
         })
         .catch()
     },
@@ -120,6 +120,7 @@ Component({
           .in(this)
           .select('#container')
           .boundingClientRect((res) => {
+            console.log(res)
             this.containerRect = {
               left: res.left, top: res.top, width: res.width, height: res.height
             }
@@ -127,9 +128,10 @@ Component({
               .in(this)
               .select('#container-view')
               .boundingClientRect(res => {
-                console.log(res)
+                const info = wx.getSystemInfoSync()
+                console.log(info.platform)
                 this.contentRect = {
-                  left: res.left, top: res.top - 8, width: res.width, height: res.height + 16
+                  left: res.left, top: res.top - 8, width: res.width, height: res.height + (info.platform === 'ios' ? 8 : 16)
                 }
                 resolve({containerRect: this.containerRect, contentRect: this.contentRect})
               })
@@ -316,8 +318,8 @@ Component({
       }
     },
     setupPullingHandle() {
-      console.log(this.properties.leadingRefresherType)
-      console.log(this.properties.trailingRefresherType)
+      // console.log(this.properties.leadingRefresherType)
+      // console.log(this.properties.trailingRefresherType)
       const leadingPullingEventAction = this.initPullingEventAction(
         this.properties.leadingRefresherType
       )
@@ -378,7 +380,7 @@ Component({
         }
       ) => {
         if (statues.value === 'refreshing') return
-        if (scrollViewOffset < 1 || scrollViewOffset === 8) {
+        if (scrollViewOffset < 1) {
           statues.value = 'pulling'
           const newPullingOffset = pullingOffset + (Math.pow(delta - 1, 3) + 1) * 20
           if (newPullingOffset <= 0) {
@@ -436,12 +438,12 @@ Component({
                         to: 0,
                         action,
                         completion: () => {
+                          innerCompletion()
                           if (outerCompletion) {
                             outerCompletion()
                           }
                           lottieRefresherAnimation.goToAndStop(0, true)
                           status.value = 'idle'
-                          innerCompletion()
                         }
                       })
                     }
@@ -498,7 +500,7 @@ Component({
             }
           default:
             return ({status}) => {
-              console.log('none')
+              // console.log('none')
               status.value = 'idle'
             }
         }
@@ -588,14 +590,15 @@ Component({
       console.log(this.trailingRefresherState)
       if (this.leadingRefresherState.value === 'pulling' || this.trailingRefresherState.value === 'pulling') return
       const {scrollTop} = e.detail
-      this.leadingScrollViewOffset = scrollTop
-      this.trailingScrollViewOffset = this.contentRect.height -
-        this.containerRect.height - this.leadingScrollViewOffset
       console.log('--------------------------')
       console.log(e.detail)
       console.log(this.contentRect)
       console.log(this.leadingScrollViewOffset)
       console.log(this.trailingScrollViewOffset)
+      this.leadingScrollViewOffset = scrollTop
+      this.trailingScrollViewOffset = this.contentRect.height -
+        this.containerRect.height - this.leadingScrollViewOffset
+
       this.sentinelLoadingHandle()
     },
     onTouchStart(e) {

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ Component({
             ) => {
               if (status.value !== 'pulling') return
               let endPullingOffset = 0
-              if (pullingOffset > pullingThreshold) {
+              if (pullingOffset > pullingThreshold && canRefresh) {
                 status.value = 'refreshing'
                 endPullingOffset = refresherHeight
 
@@ -467,11 +467,14 @@ Component({
             return (
               {
                 status,
+                canRefresh,
                 pullingOffset,
                 action
               }
             ) => {
-              status.value = 'refreshing'
+              if (canRefresh) {
+                status.value = 'refreshing'
+              }
               this._pullingBackAnimation({
                 from: pullingOffset,
                 to: 0,

--- a/src/index.wxml
+++ b/src/index.wxml
@@ -1,5 +1,5 @@
 <!--refreshable-view/refreshable-view.wxml-->
-<view style="position: relative; flex: 1">
+<view style="position: relative; height: 100%">
     <view class=".leading-refresher-container"
           style="height: {{leadingPullingOffset}}px">
         <slot wx:if="{{leadingRefresherType === 'custom-loading'}}" name="leadingRefresher"></slot>
@@ -10,7 +10,7 @@
     <scroll-view
             id="container"
             class="container"
-            style="top: {{leadingPullingOffset}}px; bottom: {{trailingPullingOffset}}px"
+            style="top: {{leadingPullingOffset - trailingPullingOffset}}px; bottom: {{trailingPullingOffset - leadingPullingOffset}}px"
             throttle="{{false}}"
             scroll-y
             enhanced="{{true}}"

--- a/src/index.wxml
+++ b/src/index.wxml
@@ -6,7 +6,7 @@
         <canvas id="leading-refresher-canvas" type="2d" style="width: 100%; height: 100%;"></canvas>
     </view>
 </view>
-<view style="flex: 1; overflow: scroll">
+<view style="flex: 2; overflow: hidden">
     <scroll-view
             id="container"
             class="container"
@@ -16,6 +16,7 @@
             bounces="{{false}}"
             show-scrollbar="{{true}}"
             bind:scroll="onScroll"
+            scroll-top="{{scrollTop}}"
     >
         <view id="container-view"
               bindtouchstart="onTouchStart"

--- a/src/index.wxml
+++ b/src/index.wxml
@@ -1,22 +1,22 @@
 <!--refreshable-view/refreshable-view.wxml-->
-<view class=".leading-refresher-container"
-      style="height: {{leadingPullingOffset}}px">
-    <slot wx:if="{{leadingRefresherType === 'custom-loading'}}" name="leadingRefresher"></slot>
-    <view wx:else class="leading-refresher">
-        <canvas id="leading-refresher-canvas" type="2d" style="width: 100%; height: 100%;"></canvas>
+<view style="position: relative; flex: 1">
+    <view class=".leading-refresher-container"
+          style="height: {{leadingPullingOffset}}px">
+        <slot wx:if="{{leadingRefresherType === 'custom-loading'}}" name="leadingRefresher"></slot>
+        <view wx:else class="leading-refresher">
+            <canvas id="leading-refresher-canvas" type="2d" style="width: 100%; height: 100%;"></canvas>
+        </view>
     </view>
-</view>
-<view style="flex: 2; overflow: hidden">
     <scroll-view
             id="container"
             class="container"
+            style="top: {{leadingPullingOffset}}px; bottom: {{trailingPullingOffset}}px"
             throttle="{{false}}"
             scroll-y
             enhanced="{{true}}"
             bounces="{{false}}"
             show-scrollbar="{{true}}"
             bind:scroll="onScroll"
-            scroll-top="{{scrollTop}}"
     >
         <view id="container-view"
               bindtouchstart="onTouchStart"
@@ -26,12 +26,12 @@
             <slot></slot>
         </view>
     </scroll-view>
-</view>
-<view class=".trailing-refresher-container"
-      style="height: {{trailingPullingOffset}}px">
-    <slot wx:if="{{trailingRefresherType === 'custom-loading'}}" name="trailingRefresher"></slot>
-    <view wx:else class="trailing-refresher">
-        <canvas id="trailing-refresher-canvas" type="2d" style="width: 100%; height: 100%;"></canvas>
+    <view class=".trailing-refresher-container"
+          style="height: {{trailingPullingOffset}}px">
+        <slot wx:if="{{trailingRefresherType === 'custom-loading'}}" name="trailingRefresher"></slot>
+        <view wx:else class="trailing-refresher">
+            <canvas id="trailing-refresher-canvas" type="2d" style="width: 100%; height: 100%;"></canvas>
+        </view>
     </view>
 </view>
 

--- a/src/index.wxss
+++ b/src/index.wxss
@@ -1,5 +1,9 @@
 /* refreshable-view/refreshable-view.wxss */
 
+:host {
+  overflow: hidden;
+}
+
 .container {
   position: absolute;
 }

--- a/src/index.wxss
+++ b/src/index.wxss
@@ -1,10 +1,5 @@
 /* refreshable-view/refreshable-view.wxss */
 
-:host {
-  display: flex;
-  flex-direction: column;
-}
-
 .container {
   position: absolute;
 }

--- a/src/index.wxss
+++ b/src/index.wxss
@@ -6,12 +6,14 @@
 }
 
 .container {
-  height: 100%;
+  position: absolute;
 }
 
 .leading-refresher-container {
   display: flex;
   flex-direction: column-reverse;
+  position: absolute;
+  top: 0;
   overflow: hidden;
   width: 100%;
 }
@@ -25,6 +27,9 @@
 .trailing-refresher-container {
   display: flex;
   flex-direction: column;
+  z-index: 3;
+  position: absolute;
+  bottom: 0;
   overflow: hidden;
   width: 100%;
 }

--- a/src/utitlies/animation.js
+++ b/src/utitlies/animation.js
@@ -274,21 +274,21 @@ export class Animation {
   }
 
   fire(action, completion) {
-    this.startTime = Date.now()
+    this.startTime = new Date().getTime()
     this.action = action
     this._doAnimation(completion)
   }
 
   _doAnimation(completion) {
-    const now = Date.now()
+    const now = new Date().getTime()
     const elapsed = now - this.startTime
     const keyframe = this.timingFunc(elapsed, this.from, this.to, this.duration)
     if (elapsed >= this.duration) {
       this.action(this.to)
+      cancelAnimationSync(this.sync)
       if (completion) {
         completion()
       }
-      cancelAnimationSync(this.sync)
       return
     }
 
@@ -296,6 +296,6 @@ export class Animation {
 
     this.sync = animationSync(() => {
       this._doAnimation(completion)
-    })
+    }, now)
   }
 }

--- a/tools/config.js
+++ b/tools/config.js
@@ -92,5 +92,5 @@ module.exports = {
     }
   },
 
-  copy: ['./assets', './utils.js'], // 将会复制到目标目录
+  copy: ['./utils.js'], // 将会复制到目标目录
 }

--- a/tools/demo/pages/index/index.js
+++ b/tools/demo/pages/index/index.js
@@ -10,7 +10,7 @@ Page({
       url: 'https://random-data-api.com/api/users/random_user?size=20',
       success: result => {
         const arr = result.data.map(res => { res.color = this.getRandomColor(); return res })
-        this.selectComponent('#refreshable-view').updateScrollViewOffsets()
+        this.selectComponent('#refreshable-view').initialize()
         this.setData({
           arr
         })

--- a/tools/demo/pages/index/index.js
+++ b/tools/demo/pages/index/index.js
@@ -41,7 +41,7 @@ Page({
   },
 
   onPulling(e) {
-    // console.log('onPulling:', e)
+    console.log('onPulling:', e)
   },
 
   onRefresh(e) {
@@ -85,10 +85,10 @@ Page({
   },
 
   onRestore(e) {
-    // console.log('onRestore:', e)
+    console.log('onRestore:', e)
   },
 
   onAbort(e) {
-    // console.log('onAbort', e)
+    console.log('onAbort', e)
   },
 })

--- a/tools/demo/pages/index/index.js
+++ b/tools/demo/pages/index/index.js
@@ -1,11 +1,34 @@
+import {RefresherType} from "../../components/index";
 
 Page({
   data: {
     arr: [],
-    canLoadMore: true,
-    triggered: false,
-    containerRect: null,
+    leadingRefresher: new RefresherType({type: 'none'}),
   },
+  onLoad() {
+    wx.request({
+      url: 'https://random-data-api.com/api/users/random_user?size=20',
+      success: result => {
+        const arr = result.data.map(res => { res.color = this.getRandomColor(); return res })
+        this.selectComponent('#refreshable-view').updateScrollViewOffsets()
+        this.setData({
+          arr
+        })
+      }
+    })
+  },
+  // onShow() {
+  //   wx.request({
+  //     url: 'https://random-data-api.com/api/users/random_user?size=20',
+  //     success: result => {
+  //       const arr = result.data.map(res => { res.color = this.getRandomColor(); return res })
+  //       this.selectComponent('#refreshable-view').outerRefreshing()
+  //       this.setData({
+  //         arr
+  //       })
+  //     }
+  //   })
+  // },
 
   getRandomColor() {
     const rgb = []

--- a/tools/demo/pages/index/index.js
+++ b/tools/demo/pages/index/index.js
@@ -41,14 +41,14 @@ Page({
   },
 
   onPulling(e) {
-    console.log('onPulling:', e)
+    // console.log('onPulling:', e)
   },
 
   onRefresh(e) {
     // e.detail.success()
     // 如果回调时间特别短会导致动画闪烁，我在考虑是否需要把基本时间判断加到内部
     const start = Date.now()
-    console.log(start)
+    // console.log(start)
     wx.request({
       url: 'https://random-data-api.com/api/users/random_user?size=20',
       success: result => {
@@ -75,7 +75,7 @@ Page({
       success: result => {
         const arr = result.data.map(res => { res.color = this.getRandomColor(); return res })
         e.detail.success(() => {
-          console.log('completion2')
+          // console.log('completion2')
           this.setData({
             arr: this.data.arr.concat(arr)
           })
@@ -85,10 +85,10 @@ Page({
   },
 
   onRestore(e) {
-    console.log('onRestore:', e)
+    // console.log('onRestore:', e)
   },
 
   onAbort(e) {
-    console.log('onAbort', e)
+    // console.log('onAbort', e)
   },
 })

--- a/tools/demo/pages/index/index.wxml
+++ b/tools/demo/pages/index/index.wxml
@@ -1,6 +1,6 @@
 
-<view style="position: absolute; top: 50px; bottom: 0; width: 100%">
-    <refreshable-view id="refreshable-view" bind:onLeadingRefreshing="onRefresh" bind:onTrailingRefreshing="loadMore" style="height: 100%">
+<view style="position: absolute; top: 50px; bottom: 0; width: 100%; display: flex; flex-direction: column">
+    <refreshable-view id="refreshable-view" bind:onLeadingRefreshing="onRefresh" bind:onTrailingRefreshing="loadMore" style="flex: 1">
         <view class="card" wx:for="{{arr}}">
             <image class="image" src="https://avatars.dicebear.com/api/micah/{{item.uid}}.svg?background=%23{{item.color}}"></image>
             <view class="content-container">

--- a/tools/demo/pages/index/index.wxml
+++ b/tools/demo/pages/index/index.wxml
@@ -1,16 +1,19 @@
-<refreshable-view bind:onLeadingRefreshing="onRefresh" canTrailingRefreshing="{{canLoadMore}}" bind:onTrailingRefreshing="loadMore" style="height: 100%">
-    <view class="card" wx:for="{{arr}}">
-        <image class="image" src="https://avatars.dicebear.com/api/micah/{{item.uid}}.svg?background=%23{{item.color}}"></image>
-        <view class="content-container">
-            <view style="display: flex; flex-direction: column; justify-content: center">
-                <text class="title">{{item.first_name + ' ' + item.last_name}}</text>
-                <view style="height: 4px"></view>
-                <text class="subtitle">{{'Birthday: ' + item.date_of_birth}}</text>
-                <view style="height: 2px"></view>
-                <text class="subtitle">{{'Country: ' + item.address.country}}</text>
+
+<view style="position: absolute; top: 50px; bottom: 0; width: 100%">
+    <refreshable-view id="refreshable-view" bind:onLeadingRefreshing="onRefresh" bind:onTrailingRefreshing="loadMore" style="height: 100%">
+        <view class="card" wx:for="{{arr}}">
+            <image class="image" src="https://avatars.dicebear.com/api/micah/{{item.uid}}.svg?background=%23{{item.color}}"></image>
+            <view class="content-container">
+                <view style="display: flex; flex-direction: column; justify-content: center">
+                    <text class="title">{{item.first_name + ' ' + item.last_name}}</text>
+                    <view style="height: 4px"></view>
+                    <text class="subtitle">{{'Birthday: ' + item.date_of_birth}}</text>
+                    <view style="height: 2px"></view>
+                    <text class="subtitle">{{'Country: ' + item.address.country}}</text>
+                </view>
+                <image wx:if="{{item.subscription.status === 'Active'}}" src="https://img.icons8.com/plasticine/100/000000/like--v2.png" style="width: 20px; height: 20px"></image>
+                <image wx:else src="https://img.icons8.com/plasticine/100/000000/like--v1.png" style="width: 20px; height: 20px"></image>
             </view>
-            <image wx:if="{{item.subscription.status === 'Active'}}" src="https://img.icons8.com/plasticine/100/000000/like--v2.png" style="width: 20px; height: 20px"></image>
-            <image wx:else src="https://img.icons8.com/plasticine/100/000000/like--v1.png" style="width: 20px; height: 20px"></image>
         </view>
-    </view>
-</refreshable-view>
+    </refreshable-view>
+</view>


### PR DESCRIPTION
1. 由于安卓与iOS的scroll-view 的设计表现不一致的问题，在使用flex 布局时，进行上拉刷新操作改变scroll-view 的高度时，在安卓端scroll-view并不会自动更改其内容位置；
2. scroll-view 会对其内容添加上下两padding，高度为8px，不明其考量；同时iOS 只会添加padding-top，而安卓跟模拟器会添加双padding；
3. 更改结构刷新的机制，使用者需要在第一次内容更新后，调用组件的initialize() 方法以帮助组件获取当前scroll-view的内容高度（也考虑过使用observer pattern，貌似意义也不大）
4. 修复了animationSync 调用时候的错误（忘记了传递lastTime， 导致setTimeOut 的delay 时间变成0，造成动画卡顿）
5. 重新梳理了pulling 的逻辑，以及sentinel loading 的逻辑，修复上下两个刷新不同时导致的蹩脚bug
6. 重新走了一遍setup的方法，因为一开始考虑在onScroll，touchMove 等方法中调用inline function 以期提高性能，不过js 的inline这块没有仔细看过，不知道有没有用，大量的绑定操作导致代码有些难读，如果没有必要后面重改一波